### PR TITLE
fix docker build problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 # Install dependencies
 COPY package.json ./
 
-#RUN npm install
+RUN npm install
 
 FROM node:lts-alpine3.16 AS builder
 WORKDIR /app


### PR DESCRIPTION
Il fallait ajouter le dossier node_modules, donc on a ajouté l'instruction `RUN npm install` au 1er stage (deps) pour installer les dependances existantes dans package.json afin de permettre au 2eme stage (Builder) de copier le dossier node_modules